### PR TITLE
Update providers.js

### DIFF
--- a/js/samsok/providers.js
+++ b/js/samsok/providers.js
@@ -128,8 +128,8 @@ var providers = [
         providers: [
             App.Provider.create({
                 parser: MinabibliotekParser,
-                baseUrl: 'http://bibliotek.boras.se/',
-                searchUrl: 'https://bibliotek.boras.se/search?query=@QUERY@&fMediaId=&fTarget=&fLang=',
+                baseUrl: 'https://knallebiblioteken.se/',
+                searchUrl: 'https://knallebiblioteken.se/search?query=@QUERY@&fMediaId=&fTarget=&fLang=',
                 name: 'Borås',
                 encoding: 'utf-8'
             }),


### PR DESCRIPTION
Borås bibliotek har startat ett delregionalt katalogsamarbete med Bollebygd, Herrljunga, Mark, Svenljunga, Tranemo, Ulricehamn och Vårgårda under namnet Knallebiblioteken.